### PR TITLE
Add ECMAScript modules

### DIFF
--- a/DarkScript3/ErrorMessageForm.cs
+++ b/DarkScript3/ErrorMessageForm.cs
@@ -12,7 +12,7 @@ namespace DarkScript3
         private static readonly TextStyle linkStyle = new TextStyle(Brushes.Blue, null, FontStyle.Underline);
         private static readonly Regex placePartsRe = new Regex(@"(\d+):(\d+)");
 
-        public Place Place { get; set; }
+        public Place? Place { get; set; }
 
         private readonly int textMarginHeight;
         private readonly int textMarginWidth;

--- a/DarkScript3/FancyJSCompiler.cs
+++ b/DarkScript3/FancyJSCompiler.cs
@@ -395,7 +395,7 @@ namespace DarkScript3
                     {
                         if (!compares.TryGetValue(bin.Operator, out ComparisonType comp))
                         {
-                            context.Error(expr, $"Operator {bin.Operator} is used when only || and && are permitted for conditions, or == != > < >= <= for comparisons");
+                            context.Error(expr, $"Operator {bin.Operator} is not permitted, only || and && for conditions, or == != > < >= <= for comparisons");
                         }
                         // RHS should be a number, but this source is copied over so it can be a variable etc.
                         CompareCond cmp = new CompareCond { Type = comp, Rhs = source.GetSourceNode(bin.Right) };
@@ -475,7 +475,7 @@ namespace DarkScript3
                 }
                 else
                 {
-                    context.Error(lhs, "Can't assign to anything other than a condition name. (Ask for feature request: using normal JS variables.)");
+                    context.Error(lhs, "Can't assign to anything other than a condition name, or a JS variable using const");
                 }
                 assign.Cond = ConvertCondExpression(rhs);
                 return assign;
@@ -577,7 +577,11 @@ namespace DarkScript3
                         }
                         else
                         {
-                            context.Error(call, $"Expected a function call with a simple named function, not a {call.Callee.Type}");
+                            // There shouldn't be anything complicated here, just simple named invocations
+                            if (call.Callee.DescendantNodesAndSelf().Any(subExpr => subExpr is IFunction))
+                            {
+                                context.Error(call, $"Expected a function call with a simple named function, not a {call.Callee.Type}");
+                            }
                         }
                         List<Expression> args = call.Arguments.ToList();
                         bool hasExpectedArgs(int expected)

--- a/DarkScript3/GUI.cs
+++ b/DarkScript3/GUI.cs
@@ -34,17 +34,16 @@ namespace DarkScript3
         {
             System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("en-US");
             InitializeComponent();
-            InfoTip.GotFocus += (object sender, EventArgs args) => editor.Focus();
             menuStrip.Renderer = new DarkToolStripRenderer();
             statusStrip.Renderer = new DarkToolStripRenderer();
             BFF = new BetterFindForm(editor);
             InfoTip = new ToolControl(editor, BFF);
+            InfoTip.GotFocus += (object sender, EventArgs args) => editor.Focus();
             BFF.infoTip = InfoTip;
             display.Panel2.Controls.Add(InfoTip);
             InfoTip.Show();
             InfoTip.Hide();
-            // TODO: Have different font sizes.
-            // This can be changed with something like new Font(editor.Font.Name, newSize);
+            // TODO: Have different fonts, using FontDialog, stored in config file or similar.
             docBox.Font = editor.Font;
             editor.Focus();
             editor.SelectionColor = Color.White;
@@ -68,7 +67,10 @@ namespace DarkScript3
             InstructionMenu.AppearInterval = 250;
 
             InstructionMenu.ImageList = new ImageList();
-            InstructionMenu.ImageList.Images.Add("instruction", MakeColorImage(Color.FromArgb(255, 255, 255)));
+            // Colors match the HTML emedf documentation
+            InstructionMenu.ImageList.Images.Add("instruction", MakeColorImage(Color.FromArgb(0xFF, 0xFF, 0xB3)));
+            InstructionMenu.ImageList.Images.Add("condition", MakeColorImage(Color.FromArgb(0xFF, 0xFF, 0xFF)));
+            InstructionMenu.ImageList.Images.Add("enum", MakeColorImage(Color.FromArgb(0xE0, 0xB3, 0xFF)));
         }
 
         #region File Handling
@@ -176,7 +178,7 @@ namespace DarkScript3
             {
                 return;
             }
-            
+
             if (ofd.FileName.EndsWith(".js"))
             {
                 OpenJSFile(ofd.FileName);
@@ -210,13 +212,18 @@ namespace DarkScript3
                 SetStyles(editor.Range);
                 SetStyles(docBox.Range);
             }
-            
-            IEnumerable<AutocompleteItem> instructions = Docs.AllArgs.Keys.Select(s =>
+
+            List<AutocompleteItem> instructions = new List<AutocompleteItem>();
+            List<AutocompleteItem> conditions = new List<AutocompleteItem>();
+            foreach (string s in Docs.AllArgs.Keys)
             {
                 string menuText = s;
+
+                // TODO: Tooltips appear to immediately disappear.
                 string toolTipTitle = s;
                 string toolTipText;
-                if (Docs.Functions.TryGetValue(s, out (int, int) indices))
+                bool isInstr = Docs.Functions.TryGetValue(s, out (int, int) indices);
+                if (isInstr)
                 {
                     toolTipText = $"{indices.Item1}[{indices.Item2}] ({ArgString(s)})";
                 }
@@ -224,19 +231,23 @@ namespace DarkScript3
                 {
                     toolTipText = $"({ArgString(s)})";
                 }
+                ToolTips[menuText] = (toolTipTitle, toolTipText);
 
-                return new AutocompleteItem(s + "(", InstructionMenu.ImageList.Images.IndexOfKey("instruction"), menuText, toolTipTitle, toolTipText);
-            });
-
-            foreach (var item in instructions)
-            {
-                ToolTips[item.MenuText] = (item.ToolTipTitle, item.ToolTipText);
-                item.ToolTipText = null;
-                item.ToolTipTitle = null;
+                if (isInstr)
+                {
+                    instructions.Add(new AutocompleteItem(s + "(", InstructionMenu.ImageList.Images.IndexOfKey("instruction"), menuText));
+                }
+                else
+                {
+                    conditions.Add(new AutocompleteItem(s + "(", InstructionMenu.ImageList.Images.IndexOfKey("condition"), menuText));
+                }
             }
-            instructions = instructions.OrderBy(i => i.Text);
+            IEnumerable<AutocompleteItem> enums = Docs.EnumValues.Keys.Select(s => new AutocompleteItem(s, InstructionMenu.ImageList.Images.IndexOfKey("enum"), s));
 
-            InstructionMenu.Items.SetAutocompleteItems(instructions);
+            InstructionMenu.Items.SetAutocompleteItems(
+                instructions.OrderBy(i => i.MenuText)
+                    .Concat(conditions.OrderBy(i => i.MenuText))
+                    .Concat(enums.OrderBy(i => i.MenuText)));
             editor.ClearUndo();
             CodeChanged = false;
         }
@@ -458,7 +469,7 @@ namespace DarkScript3
             public static TextStyle EnumProperty = MakeStyle(255, 150, 239);
             public static TextStyle EnumConstant = MakeStyle(78, 201, 176);
             public static TextStyle Number = MakeStyle(181, 206, 168);
-            public static TextStyle EnumType = MakeStyle(180,180,180);
+            public static TextStyle EnumType = MakeStyle(180, 180, 180);
         }
 
         private void customizeToolStripMenuItem_Click(object sender, EventArgs e)
@@ -548,7 +559,7 @@ namespace DarkScript3
             docBox.BackColor = editor.BackColor;
             docBox.ForeColor = editor.ForeColor;
         }
-        
+
         private void Editor_TextChanged(object sender, TextChangedEventArgs e)
         {
             statusLabel.Text = "";
@@ -614,8 +625,9 @@ namespace DarkScript3
 
         #region ToolTips
 
-        public ToolControl InfoTip { get; set; }  = new ToolControl();
-        public Range CurrentTipRange { get; set; }  = null;
+        // Reinitialized in the constructor
+        public ToolControl InfoTip { get; set; } = new ToolControl();
+        public Range CurrentTipRange { get; set; } = null;
 
         private void Editor_ToolTipNeeded(object sender, ToolTipNeededEventArgs e)
         {
@@ -698,13 +710,13 @@ namespace DarkScript3
             {
                 InfoTip.SetText(s);
             }
-            
+
             p.Offset(0, -InfoTip.Height - 5);
             if (!InfoTip.Location.Equals(p))
                 InfoTip.Location = p;
             if (!InfoTip.Visible)
                 InfoTip.Show();
-            
+
             InfoTip.BringToFront();
             editor.Focus();
         }

--- a/DarkScript3/GUI.cs
+++ b/DarkScript3/GUI.cs
@@ -1177,9 +1177,9 @@ namespace DarkScript3
             ErrorMessageForm error = new ErrorMessageForm(editor.Font);
             error.SetMessage(file, ex, extra);
             error.ShowDialog();
-            if (error.Place != Place.Empty)
+            if (error.Place is Place p)
             {
-                Range select = editor.GetRange(error.Place, error.Place);
+                Range select = editor.GetRange(p, p);
                 try
                 {
                     // Quick validity check

--- a/DarkScript3/GUI.cs
+++ b/DarkScript3/GUI.cs
@@ -428,6 +428,7 @@ namespace DarkScript3
                 sb.AppendLine("");
                 sb.AppendLine(editor.Text);
                 File.WriteAllText($"{EVD_Path}.js", sb.ToString());
+                FileVersion = ProgramVersion.VERSION;
             }
             catch (Exception ex)
             {

--- a/DarkScript3/InstructionDocs.cs
+++ b/DarkScript3/InstructionDocs.cs
@@ -28,8 +28,8 @@ namespace DarkScript3
         // Enums by display name
         public Dictionary<string, EMEDF.EnumDoc> Enums = new Dictionary<string, EMEDF.EnumDoc>();
 
-        // Enum values by value display name for fancy compilation, for control/negate args etc. which must be read as ints.
-        // These should not be packed directly into instruction args, as most enums are not actually ints.
+        // Enum values by value display name. Used for autcomplete, and also in fancy compilation
+        // where control/negate args etc. which must be read as ints.
         public Dictionary<string, int> EnumValues = new Dictionary<string, int>();
 
         // Callable objects by display name, both instructions and condition functions
@@ -344,7 +344,7 @@ namespace DarkScript3
             {
                 doc = funcDoc.ConditionDoc;
             }
-            if (doc == null) return null;
+            if (doc == null || doc.Hidden) return null;
             List<string> names = new List<string> { doc.Name };
             foreach (ConditionData.BoolVersion b in doc.AllBools)
             {

--- a/DarkScript3/ProgramVersion.cs
+++ b/DarkScript3/ProgramVersion.cs
@@ -80,6 +80,7 @@ namespace DarkScript3
             new IncompatibilityEntry("3.2", "ApplySoulScalingToWeapon requires additional arg unknown2 with default value 0", new List<string> { "ds2", "ds2scholar" }),
             new IncompatibilityEntry("3.2", "Goto/End/SkipIfPlayerInoutsideArea require additional arg numberOfTargetCharacters with default value 1", new List<string> { "ds3" }),
             new IncompatibilityEntry("3.2", "DisplayHollowArenaPvpMessage is now DisplayGenericDialogGloballyAndSetEventFlags. Get the new lines from vanilla files.", new List<string> { "sekiro" }),
+            new IncompatibilityEntry("3.2", "JavaScript is run in strict mode, so all variable assignments must be declared with let/const/var"),
         };
 
         private class IncompatibilityEntry

--- a/DarkScript3/Resources/script.js
+++ b/DarkScript3/Resources/script.js
@@ -68,10 +68,6 @@ function $LAYERS(...args) {
     return { layerValue: layer };
 }
 
-function importFile(path) {
-    eval(Scripter.Import(path))
-}
-
 class CodeBlock {
     instructions = [];
 

--- a/DarkScript3/ScriptAst.cs
+++ b/DarkScript3/ScriptAst.cs
@@ -10,7 +10,7 @@ namespace DarkScript3
     public class ScriptAst
     {
         public static readonly string SingleIndent = "    ";
-        private static readonly int columnLimit = 140;
+        private static readonly int columnLimit = 120;
 
         public class EventFunction
         {

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Note that functions like this don't act like events and still have to be called 
 so common_func is usually preferable in games where it is available. See
 [import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
 and [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export)
-for all syntax options.
+for all syntax options, including namespaced imports.
 
 ## Images
 ![DarkScript 3 screenshot](https://i.imgur.com/mKBkZuk.png)

--- a/README.md
+++ b/README.md
@@ -26,13 +26,39 @@ Event(12345, Restart, function () {
 })
 ```
 
-You can also define events or helper functions in other JS files and import them like below. **The path is relative to the program EXE, not the event file.** If you want to import a file from elsewhere, use the absolute path.
+You can also define events or helper functions in other JS files and import them as JavaScript modules.
 
 ```js
-importFile("path/to/my/file.js");
+import { Boss, BossFlag, checkBossFlag } from "mod.js";
 ```
 
-This is not a true `import` statement, so duplicate variable/const/function names –– even across different imported files –– will cause problems. Avoid this with proper scoping or fully unique naming. For instance, you couldn't define `const foo = "bar"` in one file and `const foo = "not_bar"` in another and import them both.
+An example mod.js, in the same directory as the emevd file, might look as follows:
+
+```js
+export const Boss = {
+    ARTORIAS: 1210820,
+    KALAMEET: 1210400,
+    SUPER_KALAMEET: 1210420,
+};
+
+export const BossFlag = {
+    ARTORIAS: 11210001,
+    KALAMEET: 11210004,
+    SUPER_KALAMEET: 11210006,
+};
+
+export function checkBossFlag(eventFlag) {
+    EndIfEventFlag(EventEndType.End, ON, TargetEventFlagType.EventFlag, eventFlag);
+}
+```
+
+This can be used in the emevd file like `checkBossFlag(BossFlag.SUPER_KALAMEET);`. This example is
+overly simplistic, and it might hurt script readability to make too many trivial helpers.
+Note that functions like this don't act like events and still have to be called from within events,
+so common_func is usually preferable in games where it is available. See
+[import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
+and [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export)
+for all syntax options.
 
 ## Images
 ![DarkScript 3 screenshot](https://i.imgur.com/mKBkZuk.png)


### PR DESCRIPTION
A possible way to implement imports. This ClearScript feature is a little underdocumented, but it seems like we can use a custom DocumentLoader (which can be a wrapper around the default one) to make this fully compatible with MattScript helper files.

I have verified that imported declarations work, repeated saving works, and stack traces are accurate and descriptive.

The main possible incompatibility with existing scripts is emevd files are now interpreted in strict mode. Roundtrip still works for all emevd files in regular and fancy mode, but user scripts might break. The main difference is that all assignments must be declared first (with var/let/const) and that duplicate function arguments are syntax errors. Assuming this will go in version 3.2, I've added it to ProgramVersion as a possible source of incompatibilities.