### PR TITLE
Allow opening and resaving legacy DCX types

### DIFF
--- a/DarkScript3/BetterFindForm.resx
+++ b/DarkScript3/BetterFindForm.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/DarkScript3/DarkScript3.csproj
+++ b/DarkScript3/DarkScript3.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />

--- a/DarkScript3/GUI.Designer.cs
+++ b/DarkScript3/GUI.Designer.cs
@@ -469,6 +469,7 @@ namespace DarkScript3
             this.docBox.TabStop = false;
             this.docBox.WordWrap = true;
             this.docBox.Zoom = 100;
+            this.docBox.ZoomChanged += new System.EventHandler(this.docBox_ZoomChanged);
             // 
             // GUI
             // 

--- a/README.md
+++ b/README.md
@@ -2,31 +2,27 @@
 
 User-friendly editor for FromSoftware's EMEVD format. For basic usage instructions, visit the [tutorial](http://soulsmodding.wikidot.com/tutorial:learning-how-to-use-emevd).
 
+## Images
+![DarkScript 3 screenshot](https://i.imgur.com/mKBkZuk.png)
+
 ## Tips
 
-You can use the `CodeBlock` class to avoid having to keep track of line skip counts.
+### Keyboard shortcuts
 
-```js
-Event(12345, Restart, function () {
-  
-  // create a code block
-  const block = new CodeBlock(() => {
-    SetEventFlag(760, OFF);
-    SetEventFlag(762, OFF);
-    SetEventFlag(765, OFF);
-    // ...
-    EndUnconditionally();
-  });
-  
-  // pass the length to the skip instruction
-  SkipIfEventFlag(block.length, OFF, TargetEventFlagType.EventIDAndSlotNumber, 12345000);
-  
-  // execute the block
-  block.Exec();
-})
-```
+Aside from the usual text file navigation, there are many hotkeys supported.
+Some useful ones are:
 
-You can also define events or helper functions in other JS files and import them as JavaScript modules.
+* Ctrl+F, Ctrl+H - show find/replace dialogs
+* F3 - find next
+* Ctrl+G - show goto-line dialog
+* Tab, Shift+Tab - indent/unindent text
+* Ctrl+Shift+C - comment/uncomment text
+* Ctrl+Scroll - zoom in/out
+* Ctrl+Space - open autocomplete menu
+
+### Importing other files
+
+You can define events or helper functions in other JS files and import them as JavaScript modules.
 
 ```js
 import { Boss, BossFlag, checkBossFlag } from "mod.js";
@@ -55,11 +51,35 @@ export function checkBossFlag(eventFlag) {
 This can be used in the emevd file like `checkBossFlag(BossFlag.SUPER_KALAMEET);`. This example is
 overly simplistic, and it might hurt script readability to make too many trivial helpers.
 Note that functions like this don't act like events and still have to be called from within events,
-so common_func is usually preferable in games where it is available. See
-[import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
+so common_func is usually preferable in games where it is available. For games without common_func,
+events defined in imported scripts will be added to the emevd as if they were defined in the script
+that imports them.
+
+See [import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
 and [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export)
 for all syntax options, including namespaced imports.
 
-## Images
-![DarkScript 3 screenshot](https://i.imgur.com/mKBkZuk.png)
+### CodeBlock
 
+In regular mode (using Event instead of $Event), you can use the `CodeBlock` class
+to avoid having to keep track of line skip counts.
+
+```js
+Event(12345, Restart, function () {
+  
+  // create a code block
+  const block = new CodeBlock(() => {
+    SetEventFlag(760, OFF);
+    SetEventFlag(762, OFF);
+    SetEventFlag(765, OFF);
+    // ...
+    EndUnconditionally();
+  });
+  
+  // pass the length to the skip instruction
+  SkipIfEventFlag(block.length, OFF, TargetEventFlagType.EventIDAndSlotNumber, 12345000);
+  
+  // execute the block
+  block.Exec();
+})
+```


### PR DESCRIPTION
One more compatibility thing for older files, since header values are being fully read now, and DCX.Type changed a year or so ago.

Also three other things: compile errors use the new form in all cases, zooming on the doc box caused the editor to crash, and notes on keyboard shortcuts.