### PR TITLE
UI navigation and customization improvements

### DIFF
--- a/DarkScript3/ErrorMessageForm.cs
+++ b/DarkScript3/ErrorMessageForm.cs
@@ -80,7 +80,7 @@ namespace DarkScript3
                 Match m = placePartsRe.Match(lineText);
                 if (m.Success)
                 {
-                    Place = new Place(int.Parse(m.Groups[2].Value), int.Parse(m.Groups[1].Value) - 1);
+                    Place = new Place(Math.Max(0, int.Parse(m.Groups[2].Value) - 1), Math.Max(0, int.Parse(m.Groups[1].Value) - 1));
                     Close();
                 }
             }

--- a/DarkScript3/ErrorMessageForm.cs
+++ b/DarkScript3/ErrorMessageForm.cs
@@ -25,7 +25,7 @@ namespace DarkScript3
             textMarginHeight = Height - box.Height;
             textMarginWidth = Width - box.Width;
             MinimumSize = new Size(Width, Height);
-            box.Font = font;
+            box.Font = (Font)font.Clone();
         }
 
         public void SetMessage(string file, Exception ex, string extra)

--- a/DarkScript3/EventScripter.cs
+++ b/DarkScript3/EventScripter.cs
@@ -136,8 +136,6 @@ namespace DarkScript3
                 sb.AppendLine($"EXCEPTION\nCould not write instruction at Event {CurrentEventID}, index {CurrentInsIndex}.\n");
                 sb.AppendLine($"INSTRUCTION\n{CurrentInsName} | {bank}[{index}]\n");
                 sb.AppendLine(ex.Message);
-                //sb.AppendLine("");
-                //sb.AppendLine(ex.StackTrace);
                 throw new Exception(sb.ToString());
             }
         }
@@ -218,7 +216,7 @@ namespace DarkScript3
                     foreach (var arg in args)
                     {
                         code.AppendLine($"    if ({arg} === void 0)");
-                        code.AppendLine($@"           throw '!!! Argument \""{arg}\"" in instruction \""{funcName}\"" is undefined.';");
+                        code.AppendLine($@"           throw '!!! Argument \""{arg}\"" in instruction \""{funcName}\"" is undefined or missing.';");
                     }
                     code.AppendLine($@"  var ins = _Instruction({bank.Index}, {instr.Index}, Array.from(arguments));");
                     code.AppendLine("    Scripter.CurrentInsName = \"\";");
@@ -266,18 +264,18 @@ namespace DarkScript3
         /// <summary>
         /// Generates JS source code from the EMEVD.
         /// </summary>
-        public string Unpack()
+        public string Unpack(bool compatibilityMode = false)
         {
             InitLinkedFiles();
             StringBuilder code = new StringBuilder();
             foreach (Event evt in EVD.Events)
             {
-                UnpackEvent(evt, code);
+                UnpackEvent(evt, code, compatibilityMode);
             }
             return code.ToString();
         }
 
-        public void UnpackEvent(Event evt, StringBuilder code)
+        public void UnpackEvent(Event evt, StringBuilder code, bool compatibilityMode = false)
         {
             CurrentEventID = (int)evt.ID;
 
@@ -308,7 +306,7 @@ namespace DarkScript3
                 List<object> args;
                 try
                 {
-                    args = docs.UnpackArgsWithParams(ins, insIndex, doc, paramNames, (argDoc, val) => argDoc.GetDisplayValue(val));
+                    args = docs.UnpackArgsWithParams(ins, insIndex, doc, paramNames, (argDoc, val) => argDoc.GetDisplayValue(val), compatibilityMode);
                 }
                 catch (Exception ex)
                 {

--- a/DarkScript3/GUI.Designer.cs
+++ b/DarkScript3/GUI.Designer.cs
@@ -124,6 +124,7 @@ namespace DarkScript3
             this.editor.SelectionChanged += new System.EventHandler(this.Editor_SelectionChanged);
             this.editor.VisibleRangeChangedDelayed += new System.EventHandler(this.Editor_VisibleRangeChangedDelayed);
             this.editor.ZoomChanged += new System.EventHandler(this.Editor_ZoomChanged);
+            this.editor.CustomAction += new System.EventHandler<FastColoredTextBoxNS.CustomActionEventArgs>(this.Editor_CustomAction);
             this.editor.Scroll += new System.Windows.Forms.ScrollEventHandler(this.Editor_Scroll);
             this.editor.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Editor_KeyDown);
             this.editor.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Editor_MouseUp);

--- a/DarkScript3/GUI.Designer.cs
+++ b/DarkScript3/GUI.Designer.cs
@@ -121,9 +121,11 @@ namespace DarkScript3
             this.editor.ToolTipNeeded += new System.EventHandler<FastColoredTextBoxNS.ToolTipNeededEventArgs>(this.Editor_ToolTipNeeded);
             this.editor.TextChanged += new System.EventHandler<FastColoredTextBoxNS.TextChangedEventArgs>(this.Editor_TextChanged);
             this.editor.SelectionChanged += new System.EventHandler(this.Editor_SelectionChanged);
+            this.editor.VisibleRangeChangedDelayed += new System.EventHandler(this.Editor_VisibleRangeChangedDelayed);
             this.editor.ZoomChanged += new System.EventHandler(this.Editor_ZoomChanged);
             this.editor.Scroll += new System.Windows.Forms.ScrollEventHandler(this.Editor_Scroll);
             this.editor.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Editor_KeyDown);
+            this.editor.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Editor_MouseUp);
             // 
             // menuStrip
             // 

--- a/DarkScript3/GUI.Designer.cs
+++ b/DarkScript3/GUI.Designer.cs
@@ -90,6 +90,7 @@ namespace DarkScript3
         '\"',
         '\'',
         '\''};
+            this.editor.AutoIndentChars = false;
             this.editor.AutoIndentCharsPatterns = "\r\n^\\s*[\\w\\.]+(\\s\\w+)?\\s*(?<range>=)\\s*(?<range>[^;]+);\r\n";
             this.editor.AutoScrollMinSize = new System.Drawing.Size(23, 12);
             this.editor.BackBrush = null;

--- a/DarkScript3/GUI.cs
+++ b/DarkScript3/GUI.cs
@@ -52,6 +52,7 @@ namespace DarkScript3
             LoadColors();
             InitUI();
             InfoTip.tipBox.TextChanged += (object sender, TextChangedEventArgs e) => TipBox_TextChanged(sender, e);
+            editor.HotkeysMapping.Add(Keys.Control | Keys.Enter, FCTBAction.CustomAction1);
         }
 
         private void InitUI()
@@ -943,6 +944,22 @@ namespace DarkScript3
                 return;
             }
             Place place = editor.PointToPlace(e.Location);
+            JumpToEvent(place);
+        }
+
+        private void Editor_CustomAction(object sender, CustomActionEventArgs e)
+        {
+            if (e.Action == FCTBAction.CustomAction1)
+            {
+                if (Scripter != null)
+                {
+                    JumpToEvent(editor.Selection.Start);
+                }
+            }
+        }
+
+        private void JumpToEvent(Place place)
+        {
             Range numRange = editor.GetRange(place, place).GetFragment(TextStyles.Number, false);
             if (!int.TryParse(numRange.Text, out int id))
             {

--- a/DarkScript3/GUI.cs
+++ b/DarkScript3/GUI.cs
@@ -45,7 +45,7 @@ namespace DarkScript3
             display.Panel2.Controls.Add(InfoTip);
             InfoTip.Show();
             InfoTip.Hide();
-            docBox.Font = editor.Font;
+            docBox.Font = (Font)editor.Font.Clone();
             editor.Focus();
             editor.SelectionColor = Color.White;
             docBox.SelectionColor = Color.White;
@@ -741,6 +741,7 @@ namespace DarkScript3
 
         private void SetGlobalFont(Font font, bool checkAllowed = false)
         {
+            font = (Font)font.Clone();
             if (checkAllowed)
             {
                 // FastColoredTextBox will refuse to set a monospace font (if . and M aren't the same width), so revert in that case.
@@ -757,8 +758,8 @@ namespace DarkScript3
                 }
             }
             editor.Font = font;
-            docBox.Font = font;
-            InfoTip.tipBox.Font = font;
+            docBox.Font = (Font)font.Clone();
+            InfoTip.tipBox.Font = (Font)font.Clone();
         }
 
         private List<Style> HighlightStyles;

--- a/DarkScript3/GUI.cs
+++ b/DarkScript3/GUI.cs
@@ -174,7 +174,7 @@ namespace DarkScript3
             }
             InstructionDocs oldDocs = Docs;
             OpenFileDialog ofd = new OpenFileDialog();
-            ofd.Filter = "EMEVD Files|*.emevd; *.emevd.dcx|All files|*.*";
+            ofd.Filter = "EMEVD Files|*.emevd; *.emevd.dcx|EMEVD JS Files|*.emevd.js; *.emevd.dcx.js|All files|*.*";
             if (ofd.ShowDialog() != DialogResult.OK)
             {
                 return;
@@ -681,9 +681,9 @@ namespace DarkScript3
             foreach (string line in lines)
             {
                 string[] split = line.Split(new[] { '=' }, 2);
-                string prop = split[0];
-                string val = split[1];
-                cfg[prop] = val.Trim();
+                string prop = split[0].Trim();
+                string val = split[1].Trim();
+                cfg[prop] = val;
             }
 
             Color colorFromHex(string prop) => Color.FromArgb(Convert.ToInt32(cfg[prop], 16));

--- a/DarkScript3/PreviewCompilationForm.Designer.cs
+++ b/DarkScript3/PreviewCompilationForm.Designer.cs
@@ -69,6 +69,7 @@ namespace DarkScript3
             this.fctb1.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.fctb1.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
             this.fctb1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.fctb1.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.fctb1.IsReplaceMode = false;
             this.fctb1.Location = new System.Drawing.Point(0, 0);
             this.fctb1.Name = "fctb1";
@@ -80,6 +81,7 @@ namespace DarkScript3
             this.fctb1.TabIndex = 26;
             this.fctb1.Zoom = 100;
             this.fctb1.VisibleRangeChanged += new System.EventHandler(this.fctb_VisibleRangeChanged);
+            this.fctb1.ZoomChanged += new System.EventHandler(this.fctb1_ZoomChanged);
             // 
             // fctb2
             // 
@@ -102,6 +104,7 @@ namespace DarkScript3
             this.fctb2.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.fctb2.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
             this.fctb2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.fctb2.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.fctb2.IsReplaceMode = false;
             this.fctb2.Location = new System.Drawing.Point(0, 0);
             this.fctb2.Name = "fctb2";
@@ -114,6 +117,7 @@ namespace DarkScript3
             this.fctb2.TabIndex = 27;
             this.fctb2.Zoom = 100;
             this.fctb2.VisibleRangeChanged += new System.EventHandler(this.fctb_VisibleRangeChanged);
+            this.fctb2.ZoomChanged += new System.EventHandler(this.fctb2_ZoomChanged);
             // 
             // splitContainer1
             // 

--- a/DarkScript3/PreviewCompilationForm.cs
+++ b/DarkScript3/PreviewCompilationForm.cs
@@ -20,8 +20,8 @@ namespace DarkScript3
         public PreviewCompilationForm(Font font)
         {
             InitializeComponent();
-            fctb1.Font = font;
-            fctb2.Font = font;
+            fctb1.Font = (Font)font.Clone();
+            fctb2.Font = (Font)font.Clone();
         }
 
         public void SetSegments(List<FancyJSCompiler.DiffSegment> segments, string pendingCode = null)
@@ -107,6 +107,16 @@ namespace DarkScript3
         private void lineup_CheckedChanged(object sender, EventArgs e)
         {
             RewriteSegments();
+        }
+
+        private void fctb1_ZoomChanged(object sender, EventArgs e)
+        {
+            fctb2.Font = (Font)fctb1.Font.Clone();
+        }
+
+        private void fctb2_ZoomChanged(object sender, EventArgs e)
+        {
+            fctb1.Font = (Font)fctb2.Font.Clone();
         }
     }
 }

--- a/DarkScript3/ProgramVersion.cs
+++ b/DarkScript3/ProgramVersion.cs
@@ -7,7 +7,7 @@ namespace DarkScript3
 {
     public class ProgramVersion
     {
-        public static readonly string VERSION = "3.2";
+        public static readonly string VERSION = "3.2.1";
 
         public static string GetCompatibilityMessage(string fileName, string resourceString, string fileVer)
         {

--- a/DarkScript3/StyleConfig.Designer.cs
+++ b/DarkScript3/StyleConfig.Designer.cs
@@ -30,6 +30,10 @@ namespace DarkScript3
         {
             this.okBtn = new System.Windows.Forms.Button();
             this.cancelBtn = new System.Windows.Forms.Button();
+            this.selectFont = new System.Windows.Forms.Button();
+            this.plainSetting = new DarkScript3.StyleSetting();
+            this.highlightBoxSetting = new DarkScript3.StyleSetting();
+            this.highlightSetting = new DarkScript3.StyleSetting();
             this.backgroundSetting = new DarkScript3.StyleSetting();
             this.numberSetting = new DarkScript3.StyleSetting();
             this.toolTipEnumType = new DarkScript3.StyleSetting();
@@ -39,13 +43,11 @@ namespace DarkScript3
             this.keywordSetting = new DarkScript3.StyleSetting();
             this.stringSetting = new DarkScript3.StyleSetting();
             this.commentSetting = new DarkScript3.StyleSetting();
-            this.highlightSetting = new DarkScript3.StyleSetting();
-            this.plainSetting = new DarkScript3.StyleSetting();
             this.SuspendLayout();
             // 
             // okBtn
             // 
-            this.okBtn.Location = new System.Drawing.Point(90, 360);
+            this.okBtn.Location = new System.Drawing.Point(91, 424);
             this.okBtn.Name = "okBtn";
             this.okBtn.Size = new System.Drawing.Size(75, 23);
             this.okBtn.TabIndex = 1;
@@ -56,13 +58,51 @@ namespace DarkScript3
             // cancelBtn
             // 
             this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelBtn.Location = new System.Drawing.Point(171, 360);
+            this.cancelBtn.Location = new System.Drawing.Point(172, 424);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(75, 23);
             this.cancelBtn.TabIndex = 2;
             this.cancelBtn.Text = "Cancel";
             this.cancelBtn.UseVisualStyleBackColor = true;
             this.cancelBtn.Click += new System.EventHandler(this.cancelBtn_Click);
+            // 
+            // selectFont
+            // 
+            this.selectFont.AutoSize = true;
+            this.selectFont.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.selectFont.Location = new System.Drawing.Point(12, 378);
+            this.selectFont.Name = "selectFont";
+            this.selectFont.Size = new System.Drawing.Size(77, 23);
+            this.selectFont.TabIndex = 16;
+            this.selectFont.Text = "Select font...";
+            this.selectFont.Click += new System.EventHandler(this.selectFont_Click);
+            // 
+            // plainSetting
+            // 
+            this.plainSetting.Color = System.Drawing.SystemColors.Control;
+            this.plainSetting.Dock = System.Windows.Forms.DockStyle.Top;
+            this.plainSetting.Location = new System.Drawing.Point(0, 341);
+            this.plainSetting.Name = "plainSetting";
+            this.plainSetting.Size = new System.Drawing.Size(259, 31);
+            this.plainSetting.TabIndex = 15;
+            // 
+            // highlightBoxSetting
+            // 
+            this.highlightBoxSetting.Color = System.Drawing.SystemColors.Control;
+            this.highlightBoxSetting.Dock = System.Windows.Forms.DockStyle.Top;
+            this.highlightBoxSetting.Location = new System.Drawing.Point(0, 310);
+            this.highlightBoxSetting.Name = "highlightBoxSetting";
+            this.highlightBoxSetting.Size = new System.Drawing.Size(259, 31);
+            this.highlightBoxSetting.TabIndex = 14;
+            // 
+            // highlightSetting
+            // 
+            this.highlightSetting.Color = System.Drawing.SystemColors.Control;
+            this.highlightSetting.Dock = System.Windows.Forms.DockStyle.Top;
+            this.highlightSetting.Location = new System.Drawing.Point(0, 279);
+            this.highlightSetting.Name = "highlightSetting";
+            this.highlightSetting.Size = new System.Drawing.Size(259, 31);
+            this.highlightSetting.TabIndex = 13;
             // 
             // backgroundSetting
             // 
@@ -145,24 +185,6 @@ namespace DarkScript3
             this.commentSetting.Size = new System.Drawing.Size(259, 31);
             this.commentSetting.TabIndex = 3;
             // 
-            // highlightSetting
-            // 
-            this.highlightSetting.Color = System.Drawing.SystemColors.Control;
-            this.highlightSetting.Dock = System.Windows.Forms.DockStyle.Top;
-            this.highlightSetting.Location = new System.Drawing.Point(0, 279);
-            this.highlightSetting.Name = "highlightSetting";
-            this.highlightSetting.Size = new System.Drawing.Size(259, 31);
-            this.highlightSetting.TabIndex = 13;
-            // 
-            // plainSetting
-            // 
-            this.plainSetting.Color = System.Drawing.SystemColors.Control;
-            this.plainSetting.Dock = System.Windows.Forms.DockStyle.Top;
-            this.plainSetting.Location = new System.Drawing.Point(0, 310);
-            this.plainSetting.Name = "plainSetting";
-            this.plainSetting.Size = new System.Drawing.Size(259, 31);
-            this.plainSetting.TabIndex = 14;
-            // 
             // StyleConfig
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -170,8 +192,9 @@ namespace DarkScript3
             this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.CancelButton = this.cancelBtn;
-            this.ClientSize = new System.Drawing.Size(259, 412);
+            this.ClientSize = new System.Drawing.Size(259, 459);
             this.Controls.Add(this.plainSetting);
+            this.Controls.Add(this.highlightBoxSetting);
             this.Controls.Add(this.highlightSetting);
             this.Controls.Add(this.backgroundSetting);
             this.Controls.Add(this.numberSetting);
@@ -184,6 +207,7 @@ namespace DarkScript3
             this.Controls.Add(this.commentSetting);
             this.Controls.Add(this.cancelBtn);
             this.Controls.Add(this.okBtn);
+            this.Controls.Add(this.selectFont);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
@@ -192,9 +216,10 @@ namespace DarkScript3
             this.ShowInTaskbar = false;
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Edit Colors";
+            this.Text = "Edit Appearance";
             this.Load += new System.EventHandler(this.StyleConfig_Load);
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -211,6 +236,8 @@ namespace DarkScript3
         public StyleSetting numberSetting;
         public StyleSetting backgroundSetting;
         public StyleSetting highlightSetting;
+        public StyleSetting highlightBoxSetting;
         public StyleSetting plainSetting;
+        private System.Windows.Forms.Button selectFont;
     }
 }

--- a/DarkScript3/StyleConfig.cs
+++ b/DarkScript3/StyleConfig.cs
@@ -12,16 +12,12 @@ namespace DarkScript3
 {
     public partial class StyleConfig : Form
     {
-        public StyleConfig()
-        {
-            InitializeComponent();
-        }
+        public Font FontSetting { get; set; }
 
-        public StyleConfig(GUI ds3)
+        public StyleConfig(GUI ds3, Font font)
         {
             InitializeComponent();
             StartPosition = FormStartPosition.CenterParent;
-            plainSetting.Init("Default Text", ds3.editor.ForeColor);
             commentSetting.Init("Comment", GUI.TextStyles.Comment.ForeBrush);
             stringSetting.Init("String", GUI.TextStyles.String.ForeBrush);
             keywordSetting.Init("Keyword", GUI.TextStyles.Keyword.ForeBrush);
@@ -32,6 +28,10 @@ namespace DarkScript3
             toolTipEnumType.Init("Enum Type", GUI.TextStyles.EnumType.ForeBrush);
             backgroundSetting.Init("Background", ds3.editor.BackColor);
             highlightSetting.Init("Highlight", ds3.editor.SelectionColor);
+            highlightBoxSetting.Init("Highlight Box", GUI.TextStyles.HighlightToken.BorderPen.Brush);
+            plainSetting.Init("Default Text", ds3.editor.ForeColor);
+            FontSetting = font;
+            selectFont.Font = font;
         }
 
         private void StyleConfig_Load(object sender, EventArgs e)
@@ -49,6 +49,16 @@ namespace DarkScript3
         {
             DialogResult = DialogResult.Cancel;
             Close();
+        }
+
+        private void selectFont_Click(object sender, EventArgs e)
+        {
+            FontDialog dialog = new FontDialog();
+            dialog.Font = FontSetting;
+            dialog.FontMustExist = true;
+            dialog.ShowDialog();
+            FontSetting = dialog.Font;
+            selectFont.Font = FontSetting;
         }
     }
 }

--- a/DarkScript3/StyleConfig.cs
+++ b/DarkScript3/StyleConfig.cs
@@ -30,8 +30,7 @@ namespace DarkScript3
             highlightSetting.Init("Highlight", ds3.editor.SelectionColor);
             highlightBoxSetting.Init("Highlight Box", GUI.TextStyles.HighlightToken.BorderPen.Brush);
             plainSetting.Init("Default Text", ds3.editor.ForeColor);
-            FontSetting = font;
-            selectFont.Font = font;
+            selectFont.Font = FontSetting = (Font)font.Clone();
         }
 
         private void StyleConfig_Load(object sender, EventArgs e)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ User-friendly editor for FromSoftware's EMEVD format. For basic usage instructio
 Aside from the usual text file navigation, there are many hotkeys supported.
 Some useful ones are:
 
-* Ctrl+F, Ctrl+H - show find/replace dialogs
+* Ctrl+F, Ctrl+H - show find/replace dialogs (select text first to auto-fill)
 * F3 - find next
 * Ctrl+G - show goto-line dialog
 * Tab, Shift+Tab - indent/unindent text

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Some useful ones are:
 * Ctrl+Shift+C - comment/uncomment text
 * Ctrl+Scroll - zoom in/out
 * Ctrl+Space - open autocomplete menu
+* Ctrl+Click on number - go to event definition from anywhere, or event initialization from definition
+* Ctrl+-, Ctrl+Shift+- - backwards/forwards navigation
 
 ### Importing other files
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Some useful ones are:
 * Ctrl+Shift+C - comment/uncomment text
 * Ctrl+Scroll - zoom in/out
 * Ctrl+Space - open autocomplete menu
-* Ctrl+Click on number - go to event definition from anywhere, or event initialization from definition
+* Ctrl+Click, Ctrl+Enter on number - go to event definition from anywhere, or event initialization from definition
 * Ctrl+-, Ctrl+Shift+- - backwards/forwards navigation
 
 ### Importing other files


### PR DESCRIPTION
- Allow selecting and saving a custom font and font size
- When you cursor over a word, highlight all other instances of the word in the file (translucent box around the edges with customizable color)
- Ctrl+Click on a number to go to an event definition or event id, with basic regex search
- Make Japanese text non-overlapping in comments, although pretty small as a result
- Add compatibility mode for emevd files previously saved with an incorrect number of arguments
- Fully allow opening a JS file without a corresponding emevd file