### PR TITLE
Escape string data NULL characters when saving and loading JS files

### DIFF
--- a/DarkScript3/EditorGUI.cs
+++ b/DarkScript3/EditorGUI.cs
@@ -345,9 +345,9 @@ namespace DarkScript3
             sb.AppendLine($"// @compress    {Scripter.EVD.Compression}");
             sb.AppendLine($"// @game    {Scripter.EVD.Format}");
             if (Docs.IsASCIIStringData)
-                sb.AppendLine($"// @string    {Encoding.ASCII.GetString(Scripter.EVD.StringData)}");
+                sb.AppendLine($"// @string    {Encoding.ASCII.GetString(Scripter.EVD.StringData).Replace("\0",GUI.NullStringReplaceCharacter)}");
             else
-                sb.AppendLine($"// @string    {Encoding.Unicode.GetString(Scripter.EVD.StringData)}");
+                sb.AppendLine($"// @string    {Encoding.Unicode.GetString(Scripter.EVD.StringData).Replace("\0",GUI.NullStringReplaceCharacter)}");
             sb.AppendLine($"// @linked    [{string.Join(",", Scripter.EVD.LinkedFileOffsets)}]");
             foreach (KeyValuePair<string, string> extra in Settings.SettingsDict)
             {

--- a/DarkScript3/GUI.cs
+++ b/DarkScript3/GUI.cs
@@ -18,6 +18,7 @@ namespace DarkScript3
 {
     public partial class GUI : Form
     {
+        public static readonly string NullStringReplaceCharacter = "\u001f";
         private readonly SharedControls SharedControls;
         private readonly ContextMenuStrip FileBrowserContextMenu;
         private readonly Dictionary<string, InstructionDocs> AllDocs = new Dictionary<string, InstructionDocs>();
@@ -412,7 +413,7 @@ namespace DarkScript3
                 {
                     Compression = compression,
                     Format = game,
-                    StringData = Encoding.Unicode.GetBytes(headers["string"]),
+                    StringData = Encoding.Unicode.GetBytes(headers["string"].Replace(GUI.NullStringReplaceCharacter,"\0")),
                     LinkedFileOffsets = Regex.Split(linked, @"\s*,\s*")
                         .Where(o => !string.IsNullOrWhiteSpace(o))
                         .Select(o => long.Parse(o))


### PR DESCRIPTION
Including comfy variable where you can tweak the character to escape to anytime.

I was going to make it an emoji, but this tool is supporting ASCII string data...